### PR TITLE
Use the linux-patches raw url as patches url

### DIFF
--- a/kcidb/create_object.py
+++ b/kcidb/create_object.py
@@ -101,8 +101,8 @@ data = dict(
                 "Mike Pagano <mpagano@gentoo.org>",
                 "Alice Ferrazzi <alicef@gentoo.org>"
             ],
-            patch_mboxes=get_patches_list(),
-            log_url="http://140.211.166.171:8010/api/v2/logs/" + args.patchlognumber + "/raw",
+            patch_mboxes=get_patches_list(kernel_version),
+#            log_url="http://140.211.166.171:8010/api/v2/logs/" + args.patchlognumber + "/raw",
             valid=revision_result,
         ),
     ],
@@ -112,11 +112,11 @@ data = dict(
             origin="gkernelci",
             revision_id=r_id,
             architecture=args.arch,
-            log_url="http://140.211.166.171:8010//api/v2/logs/" + args.buildlognumber + "/raw",
+#            log_url="http://140.211.166.171:8010//api/v2/logs/" + args.buildlognumber + "/raw",
             valid=build_result,
-            misc=dict(
-                url="http://140.211.166.171:8010/builders/" + args.buildernumber + "/builds/" + args.buildnumber,
-            ),
+#            misc=dict(
+#                url="http://140.211.166.171:8010/builders/" + args.buildernumber + "/builds/" + args.buildnumber,
+#            ),
         ),
     ]
 )

--- a/kcidb/get_patches.py
+++ b/kcidb/get_patches.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-def get_patches_list():
+def get_patches_list(kernel_major_version):
     patches_list=[]
     file_name="../linux-patches/0000_README"
     with open(file_name, 'r') as read_obj:
@@ -15,9 +15,7 @@ def get_patches_list():
                 patch_name=patch_name.strip(" ")
                 count += 1
             if "From:" in line:
-                patch_url=line.strip("\n")
-                patch_url=patch_url.replace("From:","")
-                patch_url=patch_url.strip(" ")
+                patch_url="https://raw.githubusercontent.com/GKernelCI/linux-patches/" + kernel_major_version + "/" + patch_name
                 count += 1
             if count==2:
                 patches_list.append({'name':patch_name, 'url':patch_url})

--- a/kcidb/send.sh
+++ b/kcidb/send.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 export GOOGLE_APPLICATION_CREDENTIALS=~/.kernelci-ci-gkernelci.json
+validate=$(kcidb-validate < data_file.json)
+if [[ $? != 0 ]]; then
+  # validation of data_file.json failed
+  echo "validation failed"
+  exit 1
+fi
+echo "validation passed"
 echo "submitting data_file.json"
 kcidb-submit -p kernelci-production -t playground_kernelci_new < data_file.json
-echo "data_file submitted"


### PR DESCRIPTION
also skip url logs for now

Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>