### PR TITLE
Permit to build and boot arm

### DIFF
--- a/all.yaml
+++ b/all.yaml
@@ -1,4 +1,20 @@
 templates:
+# Cannot use virt due to https://bugzilla.redhat.com/show_bug.cgi?id=1633328
+# a virt can be created and depend on ARM_LPAE
+  - name: qemu-arm-virt-2.11
+    arch: arm
+    devicetype: qemu
+    devicename: qemu-arm-virt-2.11
+    kernelfile: zImage
+    mach: qemu
+    qemu:
+        machine: virt-2.11
+        memory: 1024
+        cpu: cortex-a15
+        netdevice: user
+        guestfs_interface: virtio
+        console_device: ttyAMA0
+        append: "console=ttyAMA0 root=/dev/ram0"
   - name: qemu-arm64-virt
     arch: arm64
     devicetype: qemu

--- a/build-config/arm/multi_v7_defconfig/artifacts/dtb
+++ b/build-config/arm/multi_v7_defconfig/artifacts/dtb
@@ -1,0 +1,1 @@
+arch/arm/boot/dts/

--- a/build-config/arm/multi_v7_defconfig/artifacts/kernel
+++ b/build-config/arm/multi_v7_defconfig/artifacts/kernel
@@ -1,0 +1,1 @@
+arch/arm/boot/zImage

--- a/build-config/arm/multi_v7_defconfig/defconfig
+++ b/build-config/arm/multi_v7_defconfig/defconfig
@@ -1,0 +1,1 @@
+multi_v7_defconfig

--- a/gentoo_get_stage_url.sh
+++ b/gentoo_get_stage_url.sh
@@ -39,6 +39,9 @@ found_latest()
 	RFS_BPATH=/releases/$ARCH/autobuilds
 	BASEURL=$RFS_BASE$RFS_BPATH
 	case $ARCH in
+	arm)
+		SARCH=armv7a_hardfp
+	;;
 	x86)
 		SARCH=i686
 	;;

--- a/run_tests.py
+++ b/run_tests.py
@@ -25,6 +25,10 @@ def boot():
     kconfig = open("%s/config" % kdir)
     kconfigs = kconfig.read()
     kconfig.close()
+    if re.search("CONFIG_ARM=", kconfigs):
+        arch = "arm"
+        qarch = "arm"
+        larch = "arm"
     if re.search("CONFIG_ARM64=", kconfigs):
         arch = "arm64"
         qarch = "aarch64"

--- a/toolchains/x86_64/arm/gcc/opts
+++ b/toolchains/x86_64/arm/gcc/opts
@@ -1,0 +1,1 @@
+CROSS_COMPILE=arm-linux-gnueabi-


### PR DESCRIPTION
This patch adds support to build arm by using the multi_v7_defconfig.

For booting, we use the "virt" qemu machine since it is the easier to
work with. (due to virtio usage)