### PR TITLE
Detect more shell errors

### DIFF
--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 set -e
+# for catching make failing but hidden by tee
+set -o pipefail
 
 MAKEOPTS="-j$(( $(getconf _NPROCESSORS_ONLN) + 1 ))"
 

--- a/to_fileserver.sh
+++ b/to_fileserver.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 ARCH=$1
 # make cannot handle ":" in a path, so we need to replace it
 BUILDER_NAME=$(echo $2 | sed 's,:,_,g')


### PR DESCRIPTION
to_fileserver.sh was not set -e, so not exiting when cp fail.
build make errors was not atched due to tee, add pipefail to fix that.