### PR TITLE
Change default stage3 for amd64

### DIFF
--- a/gentoo_get_stage_url.sh
+++ b/gentoo_get_stage_url.sh
@@ -59,6 +59,9 @@ found_latest()
 	esac
 
 	LATEST_TXT="latest-stage3-${SARCH}.txt"
+	if [ "$SARCH" = 'amd64' ];then
+		LATEST_TXT="latest-stage3-${SARCH}-openrc.txt"
+	fi
 	curl -s "$BASEURL/$LATEST_TXT" > $LATEST_TXT
 	RET=$?
 	if [ $RET -ne 0 ];then
@@ -87,7 +90,7 @@ if [ $CHECK_SIG -eq 1 ];then
 	RET=$?
 	if [ $RET -ne 0 ];then
 		echo "ERROR: fail to download $BASEURL/$LATEST.DIGESTS.asc"
-		rm latest-stage3-$SARCH.txt
+		rm ${LATEST_TXT}
 		rm latest-stage3-$SARCH.DIGESTS
 		exit 1
 	fi


### PR DESCRIPTION
amd64 does not have anymore a simple latest-stage3-amd64.txt
So pick the openrc variant as defautl stage3.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>