### PR TITLE
Add ip=dhcp to qemu kernel cmdline

### DIFF
--- a/gentoo.jinja2
+++ b/gentoo.jinja2
@@ -98,7 +98,7 @@ actions:
          - ls -l
     images:
       stage3:
-        image_arg: '-drive format=raw,if={{ guestfs_interface }},file={gentoo} -append "root=/dev/{{ root_device }} console={{ console_device }}"'
+        image_arg: '-drive format=raw,if={{ guestfs_interface }},file={gentoo} -append "root=/dev/{{ root_device }} console={{ console_device }} ip=dhcp"'
         url: {{ ROOT_FQDN }}{{ rootfs_path }}
         compression: {{ ROOTFS_COMP }}
 {%- if rootfs_sha512 %}


### PR DESCRIPTION
We need to have a working network, so let's add ip=dhcp to kernel
cmdline.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>