### PR TITLE
Enable symlink use flag

### DIFF
--- a/docker_emerge.sh
+++ b/docker_emerge.sh
@@ -13,6 +13,7 @@ for kernel_sources in "$@"; do
       docker exec "${gentoo_rootfs}" unzip -q master.zip || exit $?
       libself_recent_ebuild=$(docker exec "${gentoo_rootfs}" find /gentoo-master/dev-libs/libelf/ -iname "*.ebuild" | sort -Vr | head -n 1)
       bc_recent_ebuild=$(docker exec "${gentoo_rootfs}" find /gentoo-master/sys-devel/bc -iname "*.ebuild" | sort -Vr | head -n 1)
+      docker exec "${gentoo_rootfs}" euse --enable symlink || exit $?
       docker exec "${gentoo_rootfs}" /usr/bin/ebuild "${libself_recent_ebuild}" clean merge || exit $?
       docker exec "${gentoo_rootfs}" /usr/bin/ebuild "${bc_recent_ebuild}" clean merge || exit $?
       docker exec "${gentoo_rootfs}" /usr/bin/ebuild /gentoo-master/"${kernel_sources}" clean merge || exit $?


### PR DESCRIPTION
We need to enable symlink use flag for having the /usr/src/linux symlink
created.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>