### PR TITLE
Kselftest should be optional

### DIFF
--- a/gentoo.jinja2
+++ b/gentoo.jinja2
@@ -220,11 +220,3 @@ actions:
           path: execs/network.yaml
           name: network
 
-- test:
-    timeout:
-        minutes: 30
-    definitions:
-        - repository: https://github.com/GKernelCI/Glava-tests.git
-          from: git
-          path: execs/kselftests.yaml
-          name: kselftests


### PR DESCRIPTION
TODO: As kselftest takes to much time we should follow
linaro kselftest and enable only the needed tests
instead of skipping results.
Also make kselftest optional.
For now removing kselftest.

Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>