### PR TITLE
fix: use amd64 for references to x86_64 since it's used in urls

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -48,7 +48,7 @@ def boot():
         qarch = "sparc64"
         larch = "sparc"
     if re.search("CONFIG_X86_64=", kconfigs):
-        arch = "x86_64"
+        arch = "amd64"
         qarch = "x86_64"
         larch = "x86_64"
     if re.search("CONFIG_X86=", kconfigs) and not re.search("CONFIG_X86_64=", kconfigs):

--- a/gentoo_get_stage_url.sh
+++ b/gentoo_get_stage_url.sh
@@ -50,7 +50,7 @@ CHECK_SIG=1
 
 found_latest()
 {
-  RFS_BPATH=/releases/$ARCH/autobuilds
+  RFS_BPATH=releases/$ARCH/autobuilds
   BASEURL=$RFS_BASE$RFS_BPATH
   case $ARCH in
   arm)
@@ -84,7 +84,8 @@ found_latest()
     fi
   fi
   echo "ROOTFS_LATEST=$BASEURL/$LATEST_TXT"
-  LATEST=$(grep -v ^# $LATEST_TXT | cut -d' ' -f1)
+  LATEST=$(grep -v ^# $LATEST_TXT | grep stage3 | cut -d' ' -f1)
+  echo LATEST=$LATEST
   return 0
 }
 


### PR DESCRIPTION
this patch comes with a couple minor fixes. One of which is that the urls referenced in
http://ftp.free.fr/mirrors/ftp.gentoo.org/releases/x86_64/autobuilds

now require using amd64 instead of x86_64. As for the other parameters, like larch and qarch, I did not think it was necessary to change to use amd64 because qemu still references their x86_64 binaries as qemu-system-x86_64 , and linux in general still uses the x86_64 wording.

As for the other change, I noticed that the following url:

http://ftp.free.fr/mirrors/ftp.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64-openrc.txt

outputs the following:

> -----BEGIN PGP SIGNED MESSAGE-----
> Hash: SHA256
>
> # Latest as of Mon, 21 Apr 2025 22:00:01 +0000
> # ts=1745272801
> 20250420T121009Z/stage3-amd64-openrc-20250420T121009Z.tar.xz 252647296
> -----BEGIN PGP SIGNATURE-----
>
> iQEzBAEBCAAdFiEEU05CCatJ7uHBnZYWLERpXbn2BD0FAmgGwCEACgkQLERpXbn2
> BD2BkAf/WLfdRz9EXCt4WjjXqyoRkx/AUnOOM5cvJKVmuPd7lKZBWex195pQ7jzE
> F9SJjkeWQVnzNmU9N/tQs4jGVpQK4ZrFe2vgMzhCH8fngZeaMsiqq3EKCLOev910
> 0Mn+jRdMubiFwm2MZO6MhGzQ6tviHlDXGuhFkEQHZ4wmI6ASRvDJyjEkDvT18hHO
> OLE6IvjRbSM2LrmQv7EA895TqXiBWMqEvAq0kPhhBFnBxr7+M2X5i6tWfcSr93nZ
> aWtdCk1MnVMRVJ9msTa8cLzgi0h6AyGNu7MykC/qqBrRpxfM2b+u9BluhoI0YM0v
> cHzupSdkpnysixAodi5SGhLJXY6GUg==
> =esY1
> -----END PGP SIGNATURE-----

And the bash scripts that try to grep out
> 20250420T121009Z/stage3-amd64-openrc-20250420T121009Z.tar.xz 252647296

seems to instead also be grabbing the signature unintentionally, which results in errors about "basename" not having the argument ----BEGIN.

closes: https://github.com/GKernelCI/GKCI-main/issues/23