### PR TITLE
fix: add extra debug statements

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -276,10 +276,12 @@ kdir = "%s/%s" % (args.fileserver, relpath)
 
 ret = boot()
 if ret != 0:
+    print("DEBUG boot() returned nonzero code: " + str(ret))
     sys.exit(1)
 
 # We should have generated at least one job
 if len(boots) == 0 and not args.noact:
+    print("DEBUG no job was generated")
     sys.exit(1)
 
 def dump_log(jobid, labname, server):
@@ -293,7 +295,8 @@ def dump_log(jobid, labname, server):
     fd = open("%s/%s.log.txt" % (lablogdir, jobid), 'w')
     try:
         r = server.scheduler.job_output(jobid)
-    except xmlrpc.client.Fault:
+    except xmlrpc.client.Fault as e:
+        print("DEBUG failed to get job output: xmlrpc.client.Fault: " + str(e))
         return 1
     logs = yaml.unsafe_load(r.data)
     for line in logs:
@@ -374,6 +377,7 @@ if len(boots) > 0 and args.waitforjobsend:
                 except TimeoutError as e:
                     print(e)
     if not all_jobs_success:
+        print("DEBUG not all jobs were successful")
         sys.exit(1)
 
 print(boots)


### PR DESCRIPTION
I was investigating the failed run today
https://gkernelci.gentoo.org/#/builders/12/builds/198

And was pretty confused from the limited output:
```
BOOT: /var/www/fileserver//6.1_amd64_gcc/amd64/198//x86_64_defconfig/gcc
INFO: arch is amd64, Linux arch is x86_64, QEMU arch is x86_64
ERROR: there is some fail
```
Based on this, I determined that deploy.py returned a status code 1 with no error message. So I searched everywhere in deploy.py for a `system.exit(1)` call with no print statement above it and added a print statement above it. That way, the next build we get, we know what line it failed on.