### PR TITLE
fix: change arch to amd64 instead of x86_64

### DIFF
--- a/all.yaml
+++ b/all.yaml
@@ -79,7 +79,7 @@ templates:
         extra_options:
         - '-vga virtio'
   - name: qemu x86_64
-    arch: x86_64
+    arch: amd64
     devicetype: qemu
     devicename: qemu-x86_64
     kernelfile: bzImage

--- a/deploy.py
+++ b/deploy.py
@@ -50,7 +50,7 @@ def boot():
     if re.search("CONFIG_X86_64=", kconfigs):
         arch = "amd64"
         qarch = "x86_64"
-        larch = "x86_64"
+        larch = "amd64"
     if re.search("CONFIG_X86=", kconfigs) and not re.search("CONFIG_X86_64=", kconfigs):
         arch = "x86"
         qarch = "i386"


### PR DESCRIPTION
In my previous commit
54e7e91da42b9ad8723173fd8547b8485666a89d

I changed a few references from x86_64 to amd64, however, I missed one that needs to refer to amd64. The reason this needs to be amd64 is because of the checks in deploy.py

        if device_larch != larch:
            continue
        if device["arch"] != arch:
            continue

defined above:
  larch = x86_64
  arch = amd64

from all.yaml:
  device["arch"] was x86_64, therefore this check device["arch"] != arch
  would be True and therefore skipped.
  And larch was x86_64, which means device_larch != larch was True.