### PR TITLE
fix: use curl instead of wget

### DIFF
--- a/gentoo_get_stage_url.sh
+++ b/gentoo_get_stage_url.sh
@@ -113,7 +113,7 @@ if [ $CHECK_SIG -eq 1 ];then
   fi
 
   debug "DEBUG: curl $LATEST"
-  wget -q -N "$BASEURL/$LATEST"
+  curl -s "$BASEURL/$LATEST" -o $(basename $LATEST)
   RET=$?
   if [ $RET -ne 0 ];then
     echo "ERROR: fail to download $BASEURL/$LATEST"


### PR DESCRIPTION
the later docker images for kernelci/qemu:latest do not have wget installed, and when testing locally, I determined this was one of the reasons for test failures.