### PR TITLE
Revert "Add testing experimental patches"

### DIFF
--- a/check-kernelpage.py
+++ b/check-kernelpage.py
@@ -241,8 +241,8 @@ for i in filenames:
     if re.match(r'^[34]', i):
         extra.append(i)
     if re.match(r'^50', i):
-        experimental.append(i)
-        #os.unlink(i)
+        #experimental.append(i)
+        os.unlink(i)
 # remove 0000_README file from the list
 base.remove("0000_README")
 print("base patch")


### PR DESCRIPTION
This reverts commit cd1ce606a987c0b59a3d53642b0fad1fb1d30914.

Experimental patches are currently not supported on gkernelci